### PR TITLE
Delete the original data directories before switching

### DIFF
--- a/snapshotter/master_pruned.sh
+++ b/snapshotter/master_pruned.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-  
+
 ZFS_NODE="new-pool/pruned"
 ZFS_POOL="new-pool/prunedSnapshot"
 NAS_LOCATION="/pokt-snap/public/pruned"
@@ -51,8 +51,21 @@ function prune() {
     cd "/$ZFS_POOL/.pocket"
     pruner "$POKT_PRUNE_BLOCK" data application,blockstore,txindexer
 
+    pruner_result=$?
+    if [ $pruner_result -ne 0 ];
+    then
+        echo "pruner failed!"
+        [ -d data/application-new.db ] && rm -rf data/application-new.db
+        [ -d data/blockstore-new.db ] && rm -rf data/blockstore-new.db
+        [ -d data/txindexer-new.db ] && rm -rf data/txindexer-new.db
+        return
+    fi
+
+    rm -rf data/application.db
     mv data/application-new.db data/application.db
+    rm -rf data/blockstore.db
     mv data/blockstore-new.db data/blockstore.db
+    rm -rf data/txindexer.db
     mv data/txindexer-new.db data/txindexer.db
 }
 


### PR DESCRIPTION
Otherwise a pruned data directory is moved as a sub-directory inside its original directory.  We should also check the exit code from pruner and delete the original directories only if pruner has finished successfully.